### PR TITLE
Sort button

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,6 +6,7 @@ mod toggle_switch;
 
 //#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
 use std::time::{Duration, SystemTime};
@@ -1710,6 +1711,60 @@ impl eframe::App for App {
                 {
                     self.lints_toggle_window = Some(WindowLintsToggle);
                 }
+
+                if ui
+                    .button("Sort modlist")
+                    .on_hover_text("Sort mods in the current profile")
+                    .clicked()
+                {
+                    let profile = self.state.mod_data.active_profile.clone();
+                    let ModData { profiles, .. } = self.state.mod_data.deref_mut().deref_mut();
+
+                    if let Some(active_profile) = profiles.get_mut(&profile) {
+                        active_profile.mods.sort_by(|a, b| {
+                            if matches!(a, ModOrGroup::Group { .. })
+                                || matches!(b, ModOrGroup::Group { .. })
+                            {
+                                unimplemented!("Groups in sorting not implemented");
+                            }
+
+                            let ModOrGroup::Individual(mc_a) = a else {
+                                debug!("Item is not Individual \n{:?}", a);
+                                return Ordering::Equal;
+                            };
+                            let ModOrGroup::Individual(mc_b) = b else {
+                                debug!("Item is not Individual \n{:?}", b);
+                                return Ordering::Equal;
+                            };
+
+                            let Some(info_a) = self.state.store.get_mod_info(&mc_a.spec) else {
+                                debug!("Failed to get mod info for \n{:?}", mc_a);
+                                return Ordering::Equal;
+                            };
+                            let Some(info_b) = self.state.store.get_mod_info(&mc_b.spec) else {
+                                debug!("Failed to get mod info for \n{:?}", mc_b);
+                                return Ordering::Equal;
+                            };
+
+                            // Orders by Enabled, then by Approval / Provider, then by Name
+                            return mc_b
+                                .enabled
+                                .cmp(&mc_a.enabled)
+                                .then_with(|| {
+                                    let Some(tags_a) = info_a.modio_tags else {
+                                        return Ordering::Equal;
+                                    };
+                                    let Some(tags_b) = info_b.modio_tags else {
+                                        return Ordering::Equal;
+                                    };
+                                    return tags_a.approval_status.cmp(&tags_b.approval_status);
+                                })
+                                .then(info_a.provider.cmp(info_b.provider))
+                                .then(info_a.name.to_lowercase().cmp(&info_b.name.to_lowercase()));
+                        });
+                    }
+                }
+
                 if ui.button("⚙").on_hover_text("Open settings").clicked() {
                     self.settings_window = Some(WindowSettings::new(&self.state));
                 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1747,8 +1747,7 @@ impl eframe::App for App {
                             };
 
                             // Orders by Enabled, then by Approval / Provider, then by Name
-                            return mc_b
-                                .enabled
+                            mc_b.enabled
                                 .cmp(&mc_a.enabled)
                                 .then_with(|| {
                                     let Some(tags_a) = info_a.modio_tags else {
@@ -1757,10 +1756,10 @@ impl eframe::App for App {
                                     let Some(tags_b) = info_b.modio_tags else {
                                         return Ordering::Equal;
                                     };
-                                    return tags_a.approval_status.cmp(&tags_b.approval_status);
+                                    tags_a.approval_status.cmp(&tags_b.approval_status)
                                 })
                                 .then(info_a.provider.cmp(info_b.provider))
-                                .then(info_a.name.to_lowercase().cmp(&info_b.name.to_lowercase()));
+                                .then(info_a.name.to_lowercase().cmp(&info_b.name.to_lowercase()))
                         });
                     }
                 }


### PR DESCRIPTION
A simple implementation of a sort button to auto-sort mods in the current profile.
It first sorts by Enabled status, then by Approval / Provider, then by Name.

Such a feature was requested in #154 and [this comment](https://github.com/trumank/mint/issues/14#issuecomment-1704321659).

Note: currently doesn't support mod groups.

![image](https://github.com/trumank/mint/assets/159221442/89c73516-bcd0-4388-a4d7-70a6e70d3f11)
