### PR TITLE
Add load priority field

### DIFF
--- a/src/gui/message.rs
+++ b/src/gui/message.rs
@@ -145,6 +145,7 @@ impl ResolveMods {
                                     spec: info.spec.clone(),
                                     required: info.suggested_require,
                                     enabled: true,
+                                    priority: 50,
                                 }),
                             );
                         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -28,7 +28,7 @@ pub struct ModConfig {
 
     #[serde(default = "default_true")]
     pub enabled: bool,
-    #[serde(default = "default_priority")]
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub priority: i32,
 }
 
@@ -36,8 +36,8 @@ fn default_true() -> bool {
     true
 }
 
-const fn default_priority() -> i32 {
-    50
+fn is_zero(value: &i32) -> bool {
+    *value == 0
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -28,10 +28,16 @@ pub struct ModConfig {
 
     #[serde(default = "default_true")]
     pub enabled: bool,
+    #[serde(default = "default_priority")]
+    pub priority: i32,
 }
 
 fn default_true() -> bool {
     true
+}
+
+const fn default_priority() -> i32 {
+    50
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -537,18 +543,21 @@ mod mod_data_tests {
             spec: ModSpecification::new("a".to_string()),
             required: false,
             enabled: false,
+            priority: 50,
         };
 
         let mod_2 = ModConfig {
             spec: ModSpecification::new("b".to_string()),
             required: true,
             enabled: false,
+            priority: 50,
         };
 
         let mod_3 = ModConfig {
             spec: ModSpecification::new("c".to_string()),
             required: false,
             enabled: true,
+            priority: 50,
         };
 
         let mod_data = ModData {
@@ -588,18 +597,21 @@ mod mod_data_tests {
             spec: ModSpecification::new("a".to_string()),
             required: false,
             enabled: false,
+            priority: 50,
         };
 
         let mod_2 = ModConfig {
             spec: ModSpecification::new("b".to_string()),
             required: true,
             enabled: false,
+            priority: 50,
         };
 
         let mod_3 = ModConfig {
             spec: ModSpecification::new("c".to_string()),
             required: false,
             enabled: true,
+            priority: 50,
         };
 
         let mod_data = ModData {
@@ -639,18 +651,21 @@ mod mod_data_tests {
             spec: ModSpecification::new("a".to_string()),
             required: false,
             enabled: false,
+            priority: 50,
         };
 
         let mod_2 = ModConfig {
             spec: ModSpecification::new("b".to_string()),
             required: true,
             enabled: false,
+            priority: 50,
         };
 
         let mod_3 = ModConfig {
             spec: ModSpecification::new("c".to_string()),
             required: false,
             enabled: true,
+            priority: 50,
         };
 
         let mod_data = ModData {


### PR DESCRIPTION
Adds a **Load Priority** field which decouples load order from the physical position in the list, as mentioned [here](https://github.com/trumank/mint/pull/157#issuecomment-2021707304).

![image](https://github.com/trumank/mint/assets/159221442/b060f23d-682a-4237-8ec4-2945037ebb09)
