### PR TITLE
Sort detailed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,16 +1419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "egui_animation"
-version = "0.1.0"
-source = "git+https://github.com/lucasmerlin/egui_dnd.git#dd739cd150af62082e0ed3bd031d71aef7f3e453"
-dependencies = [
- "egui",
- "hello_egui_utils",
- "simple-easing",
-]
-
-[[package]]
 name = "egui_commonmark"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,17 +1427,6 @@ dependencies = [
  "egui",
  "egui_extras",
  "pulldown-cmark",
-]
-
-[[package]]
-name = "egui_dnd"
-version = "0.5.1"
-source = "git+https://github.com/lucasmerlin/egui_dnd.git#dd739cd150af62082e0ed3bd031d71aef7f3e453"
-dependencies = [
- "egui",
- "egui_animation",
- "simple-easing",
- "web-time",
 ]
 
 [[package]]
@@ -2159,14 +2138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hello_egui_utils"
-version = "0.1.0"
-source = "git+https://github.com/lucasmerlin/egui_dnd.git#dd739cd150af62082e0ed3bd031d71aef7f3e453"
-dependencies = [
- "egui",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,7 +2724,6 @@ dependencies = [
  "eframe",
  "egui",
  "egui_commonmark",
- "egui_dnd",
  "fs-err",
  "futures",
  "hex",
@@ -4274,12 +4244,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simple-easing"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832ddd7df0d98d6fd93b973c330b7c8e0742d5cb8f1afc7dea89dba4d2531aa1"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ dependencies = [
  "sha2",
  "snafu",
  "steamlocate",
+ "strum 0.26.2",
  "task-local-extensions",
  "tempfile",
  "thiserror",
@@ -4434,6 +4435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros 0.26.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4451,6 +4461,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ include_dir = "0.7.3"
 postcard.workspace = true
 fs-err.workspace = true
 snafu = "0.8.0"
+strum = { version = "0.26", features = ["derive"] }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 hook = { path = "hook", artifact = "cdylib", optional = true, target = "x86_64-pc-windows-msvc"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ directories = "5.0.1"
 eframe = "0.25.0"
 egui = "0.25.0"
 egui_commonmark = "0.11.0"
-egui_dnd = { git = "https://github.com/lucasmerlin/egui_dnd.git" }
 futures = "0.3.30"
 hex = "0.4.3"
 image = { version = "0.24.7", default-features = false, features = ["png"] }

--- a/mint_lib/src/mod_info.rs
+++ b/mint_lib/src/mod_info.rs
@@ -15,7 +15,7 @@ pub struct ModioTags {
     pub approval_status: ApprovalStatus,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RequiredStatus {
     RequiredByAll,
     Optional,

--- a/src/gui/message.rs
+++ b/src/gui/message.rs
@@ -151,6 +151,7 @@ impl ResolveMods {
                         }
                     }
                     app.resolve_mod.clear();
+                    app.sort_mods();
                     app.state.mod_data.save().unwrap();
                     app.last_action_status =
                         LastActionStatus::Success("mods successfully resolved".to_string());

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -54,7 +54,7 @@ use self::toggle_switch::toggle_switch;
 pub fn gui(dirs: Dirs, args: Option<Vec<String>>) -> Result<(), MintError> {
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([800.0, 400.0])
+            .with_inner_size([900.0, 500.0])
             .with_drag_and_drop(true),
         ..Default::default()
     };

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1859,59 +1859,6 @@ impl eframe::App for App {
                 {
                     self.lints_toggle_window = Some(WindowLintsToggle);
                 }
-
-                if ui
-                    .button("Sort modlist")
-                    .on_hover_text("Sort mods in the current profile")
-                    .clicked()
-                {
-                    let profile = self.state.mod_data.active_profile.clone();
-                    let ModData { profiles, .. } = self.state.mod_data.deref_mut().deref_mut();
-
-                    if let Some(active_profile) = profiles.get_mut(&profile) {
-                        active_profile.mods.sort_by(|a, b| {
-                            if matches!(a, ModOrGroup::Group { .. })
-                                || matches!(b, ModOrGroup::Group { .. })
-                            {
-                                unimplemented!("Groups in sorting not implemented");
-                            }
-
-                            let ModOrGroup::Individual(mc_a) = a else {
-                                debug!("Item is not Individual \n{:?}", a);
-                                return Ordering::Equal;
-                            };
-                            let ModOrGroup::Individual(mc_b) = b else {
-                                debug!("Item is not Individual \n{:?}", b);
-                                return Ordering::Equal;
-                            };
-
-                            let Some(info_a) = self.state.store.get_mod_info(&mc_a.spec) else {
-                                debug!("Failed to get mod info for \n{:?}", mc_a);
-                                return Ordering::Equal;
-                            };
-                            let Some(info_b) = self.state.store.get_mod_info(&mc_b.spec) else {
-                                debug!("Failed to get mod info for \n{:?}", mc_b);
-                                return Ordering::Equal;
-                            };
-
-                            // Orders by Enabled, then by Approval / Provider, then by Name
-                            mc_b.enabled
-                                .cmp(&mc_a.enabled)
-                                .then_with(|| {
-                                    let Some(tags_a) = info_a.modio_tags else {
-                                        return Ordering::Equal;
-                                    };
-                                    let Some(tags_b) = info_b.modio_tags else {
-                                        return Ordering::Equal;
-                                    };
-                                    tags_a.approval_status.cmp(&tags_b.approval_status)
-                                })
-                                .then(info_a.provider.cmp(info_b.provider))
-                                .then(info_a.name.to_lowercase().cmp(&info_b.name.to_lowercase()))
-                        });
-                    }
-                }
-
                 if ui.button("⚙").on_hover_text("Open settings").clicked() {
                     self.settings_window = Some(WindowSettings::new(&self.state));
                 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -12,12 +12,12 @@ use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 
 use self::config::ConfigWrapper;
-use crate::providers::ProviderError;
 use crate::{
     gui::GuiTheme,
     providers::{ModSpecification, ModStore},
     Dirs,
 };
+use crate::{gui::SortBy, providers::ProviderError};
 use mint_lib::{mod_info::MetaConfig, DRGInstallation};
 
 /// Mod configuration, holds ModSpecification as well as other metadata
@@ -344,6 +344,22 @@ pub struct Config {
     pub gui_theme: Option<GuiTheme>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub disable_fix_exploding_gas: bool,
+    pub sorting_config: Option<SortingConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SortingConfig {
+    pub sort_category: SortBy,
+    pub is_ascending: bool,
+}
+
+impl Default for SortingConfig {
+    fn default() -> Self {
+        Self {
+            sort_category: SortBy::Enabled,
+            is_ascending: true,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -403,6 +419,7 @@ impl Default for Config!["0.0.0"] {
                 .map(DRGInstallation::main_pak),
             gui_theme: None,
             disable_fix_exploding_gas: false,
+            sorting_config: Some(SortingConfig::default()),
         }
     }
 }


### PR DESCRIPTION
Adds a sort bar that uses radio buttons to enable more detailed sorting by various categories.

Every category is sorted by name as well.
_Is Required_ and _Approval_ always leave non-Modio mods at the bottom.

Search moved into the sort bar and its behavior modified slightly: when nothing is focused, typing overwrites text in search and it's focused. **Enter** and **Escape** keys delete the search if it's focused.

Also, a minor increase to the default window size (looks slightly better IMO).

https://github.com/trumank/mint/assets/159221442/957fba81-fc0f-4dbf-9075-3670bc7a1d95