### PR TITLE
Fix nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
             '';
 
             postInstall = ''
-              wrapProgram $out/bin/mint \
+              wrapProgram $out/bin/${packageName} \
                 --prefix LD_LIBRARY_PATH : "${libraryPath}" \
                 --prefix XDG_DATA_DIRS : "${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}"
             '';
@@ -83,6 +83,7 @@
                 description = "Deep Rock Galactic mod loader and integration";
                 license = licenses.mit;
                 homepage = "https://github.com/trumank/mint";
+                mainProgram = packageName;
             };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             rustToolchain
             pkg-config
             mingwCompiler
+            makeWrapper
         ];
 
         libraryPath = lib.makeLibraryPath libs;
@@ -70,6 +71,12 @@
             preConfigure = ''
                 export LD_LIBRARY_PATH="${libraryPath}"
                 export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="${mingwRustflags}";
+            '';
+
+            postInstall = ''
+              wrapProgram $out/bin/mint \
+                --prefix LD_LIBRARY_PATH : "${libraryPath}" \
+                --prefix XDG_DATA_DIRS : "${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}"
             '';
 
             meta = with lib; {


### PR DESCRIPTION
Currently the Nix package fails to launch. This fixes that by wrapping the package with the necessary runtime libraries.