### PR TITLE
Rename "install mods" and "uninstall mods" to better reflect what they do

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1762,7 +1762,9 @@ impl eframe::App for App {
                         }
 
                         ui.add_enabled_ui(self.state.config.drg_pak_path.is_some(), |ui| {
-                            let mut button = ui.button("Install mods");
+                            let mut button = ui.button("Apply changes").on_hover_text(
+                                "Install the hook dll to game folder and regenerate mod bundle",
+                            );
                             if self.state.config.drg_pak_path.is_none() {
                                 button = button.on_disabled_hover_text(
                                     "DRG install not found. Configure it in the settings menu.",
@@ -1800,7 +1802,9 @@ impl eframe::App for App {
                         });
 
                         ui.add_enabled_ui(self.state.config.drg_pak_path.is_some(), |ui| {
-                            let mut button = ui.button("Uninstall mods");
+                            let mut button = ui.button("Uninstall hook and mods").on_hover_text(
+                                "Remove the hook dll and mod bundle from game folder",
+                            );
                             if self.state.config.drg_pak_path.is_none() {
                                 button = button.on_disabled_hover_text(
                                     "DRG install not found. Configure it in the settings menu.",


### PR DESCRIPTION
A common confusion for new mint users is that they don't remember to click "Install mods" after modifying the active mod profile. "Install mods" is probably confusing because it could ambiguously imply only a one-time installation is required, whereas the user actually needs to click "Install mods" on every change.

A future improvement could have the GUI and/or state track modifications to the active profile and mark GUI as "dirty" and highlight "Apply changes", but I'll keep this PR simple and rename the button as a first step.

- Rename "Install mods" -> "Apply changes" to be less confusing.
- Rename "Uninstall mods" -> "Uninstall hook and mods".
- Added hover text for both buttons to help explain what they do.

<img width="677" alt="Screenshot 2024-08-04 130540" src="https://github.com/user-attachments/assets/7ec399eb-4dee-4ef1-9a54-7d176ba38c40">

Closes #230.