### PR TITLE
Replace radial button selection with comboboxes

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2003,25 +2003,61 @@ impl eframe::App for App {
                     .map(|c| (Some(c.sort_category), c.is_ascending))
                     .unwrap_or_default();
 
-                let mut clicked = ui.radio_value(&mut sort_category, None, "Manual").clicked();
-                for category in SortBy::iter() {
-                    let mut radio_label = category.as_str().to_owned();
-                    if sort_category == Some(category) {
-                        radio_label.push_str(if is_ascending { " ⏶" } else { " ⏷" });
-                    }
-                    let resp = ui.radio_value(&mut sort_category, Some(category), radio_label);
-                    if resp.clicked() {
-                        clicked = true;
-                        if resp.changed() {
-                            is_ascending = true;
-                        } else {
-                            is_ascending = !is_ascending;
+                egui::ComboBox::from_id_salt("sort_cat")
+                .selected_text(
+                    {
+                        match sort_category {
+                            None => "Manual",
+                            Some(category) => category.as_str(),
                         }
+                    }
+                    .to_string(),
+                )
+                .show_ui(ui, |ui| {
+                    if ui
+                        .selectable_value(&mut sort_category, None, "Manual")
+                        .clicked()
+                    {
+                        self.update_sorting_config(sort_category, is_ascending);
                     };
-                }
-                if clicked {
-                    self.update_sorting_config(sort_category, is_ascending);
-                }
+                    for category in SortBy::iter() {
+                        let combo_label = category.as_str().to_owned();
+                        if ui
+                            .selectable_value(
+                                &mut sort_category,
+                                Some(category),
+                                combo_label,
+                            )
+                            .clicked()
+                        {
+                            self.update_sorting_config(sort_category, is_ascending);
+                        };
+                    }
+                });
+
+                ui.label("Order: ");
+
+                ui.add_enabled_ui(sort_category.is_some(), |ui| {
+                    egui::ComboBox::from_id_salt("order")
+                        .selected_text(match is_ascending {
+                            true => "Ascending",
+                            false => "Descending",
+                        })
+                        .show_ui(ui, |ui| {
+                            if ui
+                                .selectable_value(&mut is_ascending, true, "Ascending")
+                                .clicked()
+                            {
+                                self.update_sorting_config(sort_category, is_ascending);
+                            }
+                            if ui
+                                .selectable_value(&mut is_ascending, false, "Descending")
+                                .clicked()
+                            {
+                                self.update_sorting_config(sort_category, is_ascending);
+                            }
+                        });
+                });
 
                 ui.add_space(16.);
                 // TODO: actually implement mod groups.


### PR DESCRIPTION
An option to sort mod view is pretty cool, but i felt like radio buttons made UI a bit cluttery.
I've made an alternative that's more compact.
![image](https://github.com/user-attachments/assets/d6fc6e85-e73a-4bab-8be2-c9178a368961)
