### PR TITLE
Fix mod.io regex to accept new format

### DIFF
--- a/src/providers/modio.rs
+++ b/src/providers/modio.rs
@@ -17,7 +17,7 @@ use crate::providers::*;
 
 static RE_MOD: OnceLock<regex::Regex> = OnceLock::new();
 fn re_mod() -> &'static regex::Regex {
-    RE_MOD.get_or_init(|| regex::Regex::new("^https://mod.io/g/drg/m/(?P<name_id>[^/#]+)(:?#(?P<mod_id>\\d+)(:?/(?P<modfile_id>\\d+))?)?$").unwrap())
+    RE_MOD.get_or_init(|| regex::Regex::new("^https://mod\\.io/g/drg/m/(?P<name_id>[^/#]+)(?:#(?:(?P<mod_id>\\d+)(?:/(?P<modfile_id>\\d+))?|[a-z]+))?$").unwrap())
 }
 
 const MODIO_DRG_ID: u32 = 2475;


### PR DESCRIPTION
- Allow for the new mod.io default links with `#...`, e.g. `https://mod.io/g/drg/m/a-better-modding-menu#description`
- Assuming `:?` was intended as non-capturing groups - not optional `:` - swapped them to `?:`